### PR TITLE
fix(version): 开发环境跳过版本不一致提示并修复 dev-sw 常量缺失

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -12,7 +12,18 @@ declare let self: ServiceWorkerGlobalScope & {
 
 // 缓存版本控制
 const RESOURCE_VERSION = 'V2'
-const CACHE_VERSION = `${__APP_VERSION__}-${__BUILD_TIME__}` // 开发环境下无法使用此环境变量，生产环境正常
+// 开发态 dev-sw 可能拿不到 Vite define 注入；仅在开发环境做 dev 兜底
+const hasAppVersion = typeof __APP_VERSION__ !== 'undefined'
+const hasBuildTime = typeof __BUILD_TIME__ !== 'undefined'
+const isDev = import.meta.env.DEV
+
+if (!isDev && (!hasAppVersion || !hasBuildTime)) {
+  throw new Error('[SW] Missing __APP_VERSION__ or __BUILD_TIME__ in production build')
+}
+
+const appVersion = hasAppVersion ? __APP_VERSION__ : 'dev'
+const buildTime = hasBuildTime ? __BUILD_TIME__ : 'dev'
+const CACHE_VERSION = `${appVersion}-${buildTime}`
 
 // 启用导航预载
 navigationPreload.enable()

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -23,6 +23,14 @@ export const useGlobalSettingsStore = defineStore('globalSettings', {
 
         // 检查版本更新
         if (result.FRONTEND_VERSION) {
+          const isBackendDev = Boolean(result.BACKEND_DEV)
+          const skipVersionCheck = import.meta.env.DEV || isBackendDev
+
+          if (skipVersionCheck) {
+            console.log('[VersionChecker] 开发环境下跳过版本一致性检查')
+            return
+          }
+
           const { checkVersion } = useVersionChecker()
           await checkVersion(result.FRONTEND_VERSION)
         }


### PR DESCRIPTION
变更说明\n- 前端初始化时，若前端开发环境或后端返回 BACKEND_DEV=true，跳过版本一致性提示\n- 修复 service-worker 在 dev-sw 场景下 APP_VERSION 与 BUILD_TIME 常量可能缺失导致的报错\n- 常量缺失时仅在开发环境回退为 dev，不影响生产构建路径\n\n影响路径\n- src/stores/global.ts\n- src/service-worker.ts\n\n复现与验证\n1. 前端 yarn dev + 后端 DEV=true 启动，页面不再弹出版本不一致提示\n2. 开发环境下 Service Worker 不再出现 APP_VERSION is not defined\n3. 执行 yarn typecheck 通过\n\n本 PR 为 codex 协作提交